### PR TITLE
Fixed Button Input Styling by actually hiding the inner Input Element

### DIFF
--- a/src/components/context_stuffing/PdfContextModal.js
+++ b/src/components/context_stuffing/PdfContextModal.js
@@ -1,6 +1,6 @@
 // src/components/context_stuffing/PdfContextModal.js
 import React, { useState, useRef } from 'react';
-import { Dialog, DialogTitle, DialogContent, DialogActions, Button, TextField, Box, Typography, Input } from '@mui/material';
+import { Dialog, DialogTitle, DialogContent, DialogActions, Button, TextField, Box, Typography } from '@mui/material';
 import CloudUploadIcon from '@mui/icons-material/CloudUpload';
 
 const PdfContextModal = ({ open, onClose, onSubmit }) => {
@@ -103,10 +103,10 @@ const PdfContextModal = ({ open, onClose, onSubmit }) => {
                         disabled={!!pdfUrl.trim()}
                     >
                         Upload PDF (Option 2)
-                        <Input
+                        <input
                             type="file"
                             hidden
-                            inputRef={fileInputRef}
+                            ref={fileInputRef}     
                             onChange={handleFileChange}
                             accept="application/pdf"
                         />


### PR DESCRIPTION
# PR Template: Bug Fix

## Description of the Bug
Provide a brief explanation of the bug this PR addresses:

* the browse files button should be stylized like the Fetch & Add Button
* in 'Stuff PDF Context'
* looked really bad

![image](https://github.com/user-attachments/assets/a511b66b-b8aa-4daa-b23a-05b94ce73f77)

## Fix Implementation
Describe how the fix resolves the problem:

* changed MUI `<Input/>` Element to HTML `<input/>` Element => hiding the MUI Element is much more difficult because of the wrapper
* easy fix with good readability & same functionality

![image](https://github.com/user-attachments/assets/102ac45a-2e9b-44b0-b826-442f8a30ab02)

## Related Issues
List any linked issues or PRs:

#58 

## Testing Performed
Summarize what was tested and how:

* had problems with firebase setup => did not perform any tests
* copied the file into a custom react project to verify the working file input

## Code Changes
Outline the files or logic impacted:

* src/components/context_stuffing/PdfContextModal.js
* MUI Input Element import removed

## Verification Steps
List steps to verify the fix works:

1. Set up the environment
2. Reproduce the original bug
3. Confirm the fix prevents it
4. Check for regressions

## Checklist
* [x] Fix is documented if applicable
* [ ] Tests are added or updated
* [ ] All tests pass locally
* [ ] Code follows style guidelines
* [x] No sensitive info included
