### PR TITLE
repo metrics runs only on main branch

### DIFF
--- a/.github/workflows/collect_metrics.yml
+++ b/.github/workflows/collect_metrics.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   collect-and-upload-metrics:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: read  # Read repo content (needed for repo object)


### PR DESCRIPTION
# PR Template: Bug Fix #32 

Collect Repo Metrics and Upload to S3 workflow now only runs on main branch



## Checklist
* [ ] Fix is documented if applicable
* [ ] Tests are added or updated
* [ ] All tests pass locally
* [x] Code follows style guidelines
* [ ] No sensitive info included

## Additional Context
Add anything useful for reviewers:

* Links to discussions, decisions, or resources
* Known limitations or follow-up tasks
