### PR TITLE
Bug Bashed: Double Context Bubble

### DIFF
--- a/src/pages/ChatPage.js
+++ b/src/pages/ChatPage.js
@@ -425,7 +425,7 @@ const ChatPage = () => {
                                 )}
 
                                 {/* Render each legacy file_data as its own context bubble below the message */}
-                                {fileDataParts.map((part, idx) => {
+                                {!isContextMessage && fileDataParts.map((part, idx) => {
                                     const item = convertPartToContextItem(part);
                                     const openDetails = () => {
                                         setContextDetailsItems([item]);


### PR DESCRIPTION
No JIRA

There was an aestheic bug where a context bubble would be rendered twice. Now it's fixed and only renders once, as expected. 

---