### PR TITLE
Closes #166 - Fixes GitHub Actions From Running In Forked Repositories

### DIFF
--- a/.github/workflows/collect_metrics.yml
+++ b/.github/workflows/collect_metrics.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read  # Read repo content (needed for repo object)
-
+    if: github.repository == 'The-AI-Alliance/agent-lab-ui'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
# PR Template: Bug Fix

## Description of the Bug
Closes #166 - Fixes GitHub Actions From Running In Forked Repositories

## Fix Implementation
Added check to see if the GitHub Action about to fire is in the main repository. If it is, fire. If not, exit without error. 

## Related Issues
 #166 - GitHub Actions From Running In Forked Repositories

* Issue references (e.g., #123)
* Related PRs (if applicable)

## Testing Performed
Verified job exited when run manually without error in the forked repository

## Code Changes
`.github/workflows/collect_metrics.yml` modified with 'if' check

## Verification Steps
Verified job exited without error in the forked repository


## Checklist
* [ ] Fix is documented if applicable
* [ ] Tests are added or updated
* [ ] All tests pass locally
* [X] Code follows style guidelines
* [X] No sensitive info included

## Additional Context
None
