### PR TITLE
fix: failed loop agent deploys

### DIFF
--- a/functions/common/adk_helpers.py
+++ b/functions/common/adk_helpers.py
@@ -434,7 +434,7 @@ async def instantiate_adk_agent_from_config(agent_config, parent_adk_name_for_co
         if not model_id:
             raise ValueError(f"Agent '{original_agent_name}' is of type {agent_type_str} but is missing required 'modelId'.")
 
-            # Fetch the model configuration from Firestore
+        # Fetch the model configuration from Firestore
         model_config = await get_model_config_from_firestore(model_id)
 
         # Merge agent-specific properties (like tools, outputKey) with the model's properties.
@@ -478,25 +478,23 @@ async def instantiate_adk_agent_from_config(agent_config, parent_adk_name_for_co
                 logger.error(f"Traceback:\n{detailed_traceback}")
                 raise ValueError(f"Failed to instantiate looped child agent for '{original_agent_name}': {e_loop_child_init}.")
 
-            max_loops_val_str = agent_config.get("maxLoops", "3") # Default to 3 loops
+            max_iterations_str = agent_config.get("maxLoops", "3")  # Using maxLoops as config key, rename to max_iterations internally
             try:
-                max_loops_val = int(max_loops_val_str)
-                if max_loops_val <= 0: # Max loops must be positive
-                    logger.warning(f"MaxLoops for LoopAgent '{adk_agent_name}' is {max_loops_val}, which is not positive. Defaulting to 3.")
-                    max_loops_val = 3
+                max_iterations = int(max_iterations_str)
+                if max_iterations <= 0:  # Must be positive
+                    logger.warning(f"maxLoops for LoopAgent '{adk_agent_name}' is {max_iterations}, which is not positive. Defaulting to 3.")
+                    max_iterations = 3
             except ValueError:
-                logger.warning(f"Invalid MaxLoops value '{max_loops_val_str}' for LoopAgent '{adk_agent_name}'. Defaulting to 3.")
-                max_loops_val = 3
-
+                logger.warning(f"Invalid maxLoops value '{max_iterations_str}' for LoopAgent '{adk_agent_name}'. Defaulting to 3.")
+                max_iterations = 3
 
             loop_agent_kwargs = {
                 "name": adk_agent_name,
                 "description": agent_config.get("description"),
-                "agent": looped_child_agent_instance, # The LlmAgent to loop
-                "max_loops": max_loops_val
-                # Potentially other LoopAgent specific params like "stopping_condition" if supported/configured
+                "sub_agents": [looped_child_agent_instance],  # Pass as list
+                "max_iterations": max_iterations,              # Correct parameter name
             }
-            logger.debug(f"Final kwargs for LoopAgent '{adk_agent_name}': {{name, description, max_loops, agent_name: {looped_child_agent_instance.name}}}")
+            logger.debug(f"Final kwargs for LoopAgent '{adk_agent_name}': {{name, description, max_iterations, sub_agents count: {len(loop_agent_kwargs['sub_agents'])}}}")
             return LoopAgent(**loop_agent_kwargs)
 
     elif AgentClass == SequentialAgent or AgentClass == ParallelAgent:


### PR DESCRIPTION
Fixes #90 

There were two issues, the parameter `max_loops` should have been `max_iterations` and it expected a list of subagents, not a single agent. 
---